### PR TITLE
Add commit tracking for base PKHeX

### DIFF
--- a/cogs/polling.py
+++ b/cogs/polling.py
@@ -1,7 +1,6 @@
 import discord
 import aiohttp
 import asyncio
-from urllib.request import urlopen
 import json, time
 
 from discord.ext import commands

--- a/cogs/polling.py
+++ b/cogs/polling.py
@@ -25,7 +25,9 @@ class CommitTracker:
         commit = self.bot.config['basecommit']
         while True:
             oldcommit=commit
-            data = await self.get_latest_commit('kwsch', 'pkhex') 
+            owner = 'kwsch'
+            repo = 'pkhex'
+            data = await self.get_latest_commit(owner, repo) 
             try:
                 commitdata = json.loads(data)[0]
             except KeyError:
@@ -41,7 +43,7 @@ class CommitTracker:
                     conf.truncate()
                     json.dump(newconfig, conf, indent=4)
                 embed = discord.Embed(color=7506394)
-                embed.title = "[PKHeX:master] 1 new commit"
+                embed.title = "[{repo}:master] 1 new commit".format(repo=repo)
                 embed.url = commitdata['html_url']
                 embed.set_author(name=commitdata['author']['login'], icon_url=commitdata['author']['avatar_url'], url=commitdata['author']['html_url'])
                 embed.description = "[`{shortcommithash}`]({commiturl}) {commitmessage} - {commitauthor}".format(shortcommithash=commit[0:7], commiturl=commitdata['html_url'], commitmessage=commitdata['commit']['message'].split("\n\n")[0], commitauthor=commitdata['author']['login'])

--- a/cogs/polling.py
+++ b/cogs/polling.py
@@ -1,0 +1,54 @@
+import discord
+import aiohttp
+import asyncio
+from urllib.request import urlopen
+import json, time
+
+from discord.ext import commands
+from .utils import checks
+
+
+class CommitTracker:
+    def __init__(self, bot):
+        self.bot = bot
+        self.base_commit = bot.config['basecommit']
+        self.wait_time = 120
+
+    async def get_latest_commit(self, owner, repo):
+        url = 'https://api.github.com/repos/{owner}/{repo}/commits?per_page=1'.format(owner=owner, repo=repo)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                return await response.text()
+
+    async def trackCommits(self):
+        await self.bot.wait_until_ready()
+        commit = self.bot.config['basecommit']
+        while True:
+            oldcommit=commit
+            data = await self.get_latest_commit('kwsch', 'pkhex') 
+            try:
+                commitdata = json.loads(data)[0]
+            except KeyError:
+                print(json.loads(data))
+            commit = commitdata['sha']
+            if commit != oldcommit:
+                oldcommit = commit
+                self.bot.config['basecommit'] = commit
+                with open("config.json", 'r+') as conf:
+                    newconfig = json.load(conf)
+                    newconfig['basecommit'] = commit
+                    conf.seek(0)
+                    conf.truncate()
+                    json.dump(newconfig, conf, indent=4)
+                embed = discord.Embed(color=7506394)
+                embed.title = "[PKHeX:master] 1 new commit"
+                embed.url = commitdata['html_url']
+                embed.set_author(name=commitdata['author']['login'], icon_url=commitdata['author']['avatar_url'], url=commitdata['author']['html_url'])
+                embed.description = "[`{shortcommithash}`]({commiturl}) {commitmessage} - {commitauthor}".format(shortcommithash=commit[0:7], commiturl=commitdata['html_url'], commitmessage=commitdata['commit']['message'].split("\n\n")[0], commitauthor=commitdata['author']['login'])
+                await self.bot.basecommits_channel.send(embed=embed)
+            await asyncio.sleep(self.wait_time)
+
+def setup(bot):
+    c = CommitTracker(bot)
+    bot.loop.create_task(c.trackCommits())
+    bot.add_cog(c)

--- a/cogs/polling.py
+++ b/cogs/polling.py
@@ -26,7 +26,7 @@ class CommitTracker:
         while True:
             oldcommit=commit
             owner = 'kwsch'
-            repo = 'pkhex'
+            repo = 'PKHeX'
             data = await self.get_latest_commit(owner, repo) 
             try:
                 commitdata = json.loads(data)[0]

--- a/porygon.py
+++ b/porygon.py
@@ -87,6 +87,7 @@ if __name__ == "__main__":
         bot.commits_channel = main_server.get_channel(401017666577629214)
         bot.modlog_channel = main_server.get_channel(431429919185174547)
         bot.general_channel = main_server.get_channel(401014193211441161)
+        bot.basecommits_channel = main_server.get_channel(434030604179472384)
 
     for extension in os.listdir("cogs"):
         if extension.endswith('.py'):


### PR DESCRIPTION
Current polling delay set at 120 seconds. Seems to work fine without being rate limited. Rate limit is for unauth API requests is 60 an hour. Needs an extra item in `config.json`. Initialize with key `basecommit` and value as an empty string