### PR TITLE
Add invite whitelisting filters

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -235,6 +235,7 @@ class Mod(commands.Cog):
                 continue
             if invite.id in self.whitelisted_guild_ids:
                 await message.author.add_roles(self.bot.mute_role, reason="Posted non-whitelisted invite")
+                await message.delete()
                 return await self.bot.modlog_channel.send("Muted user posting a non-whitelisted invite : {} ({}) for the following invite to the `{}` guild: ```{}```".format(author, author.id, invite.guild.name, invite.url))
 
     @commands.command(name='promote', aliases=['addrole'])

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -234,7 +234,7 @@ class Mod(commands.Cog):
                 invite = await self.bot.fetch_invite(phrase)
             except discord.NotFound:
                 continue
-            if invite.id in self.whitelisted_guild_ids and not message.channel.id == 683403876208083026:  # ID 683403876208083026 = #list-your-sysbot-server
+            if invite.id in self.whitelisted_guild_ids and message.channel.id not in (683403876208083026, 683403966607786058):  # ID 683403876208083026 = #list-your-sysbot-server, ID 683403966607786058 = #sysbot-servers
                 await message.author.add_roles(self.bot.mute_role, reason="Posted non-whitelisted invite")
                 await message.delete()
                 return await self.bot.modlog_channel.send("Muted user posting a non-whitelisted invite : {} ({}) for the following invite to the `{}` guild: ```{}```".format(author, author.id, invite.guild.name, invite.url))

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -234,7 +234,7 @@ class Mod(commands.Cog):
                 invite = await self.bot.fetch_invite(phrase)
             except discord.NotFound:
                 continue
-            if invite.id in self.whitelisted_guild_ids:
+            if invite.id in self.whitelisted_guild_ids and not message.channel.id == 683403876208083026:  # ID 683403876208083026 = #list-your-sysbot-server
                 await message.author.add_roles(self.bot.mute_role, reason="Posted non-whitelisted invite")
                 await message.delete()
                 return await self.bot.modlog_channel.send("Muted user posting a non-whitelisted invite : {} ({}) for the following invite to the `{}` guild: ```{}```".format(author, author.id, invite.guild.name, invite.url))


### PR DESCRIPTION
- Creates `whitelisted_guild_ids.json` on `mod.py` loading if doesn't exist as an empty list.
- `whitelist_guild` (name set to `wlguild`) and `dewhitelist_guild` (name set to `dewlguild`) allows adding and removing to the list as needed.
- On message does a simple split and iterates through, looking for an invite code. Didn't regex, but this should catch standalone invite codes and url invite codes (eg `pkhex` and `https://discord.gg/pkhex`, accordingly) 99% of the time. 
  - Deletes message, but will only mute users, not ban. Escalation to be done at a staff member's choice.
- Excludes #list-your-sysbot-server and #sysbot-servers from the check, allowing invites to still be requested
  - #sysbot-servers needs to be excluded as well due to Klutch, and the possibility of others not in the `(aww, Moderators, Porygon)` set, being able to post new approved invites there

Should probably be moved from json to db at some point but this'll work for now.